### PR TITLE
Fixed Content-Length deletion for reverse proxies in Martini

### DIFF
--- a/gzip.go
+++ b/gzip.go
@@ -59,12 +59,12 @@ func All(options ...Options) martini.Handler {
 
 func prepareOptions(options []Options) Options {
 	var opt Options
-        if len(options) > 0 {
-                opt = options[0]
-        }
-        if !isCompressionLevelValid(opt.CompressionLevel) {
-                opt.CompressionLevel = DefaultCompression
-        }
+	if len(options) > 0 {
+		opt = options[0]
+	}
+	if !isCompressionLevelValid(opt.CompressionLevel) {
+		opt.CompressionLevel = DefaultCompression
+	}
 	return opt
 }
 
@@ -88,7 +88,9 @@ func (grw gzipResponseWriter) Write(p []byte) (int, error) {
 	if len(grw.Header().Get(HeaderContentType)) == 0 {
 		grw.Header().Set(HeaderContentType, http.DetectContentType(p))
 	}
-
+	// removing content length before writing in case gzip.Writer writes to the
+	// underlying http.ResponseWriter before closing. See notes in compress/gzip.
+	grw.Header().Del("Content-Length")
 	return grw.w.Write(p)
 }
 

--- a/gzip.go
+++ b/gzip.go
@@ -84,6 +84,11 @@ type gzipResponseWriter struct {
 	martini.ResponseWriter
 }
 
+func (grw gzipResponseWriter) WriteHeader(a int) {
+	grw.Header().Del("Content-Length")
+	grw.ResponseWriter.WriteHeader(a)
+}
+
 func (grw gzipResponseWriter) Write(p []byte) (int, error) {
 	if len(grw.Header().Get(HeaderContentType)) == 0 {
 		grw.Header().Set(HeaderContentType, http.DetectContentType(p))


### PR DESCRIPTION
It turns out that deleting Content-Length header field at the end of
serveGzip function may not be enough for gzip. According to the spec
of compress/gzip, a Write() call may flush the writer before closing
it. This means that in certain cases, gzip writer flushes compressed
data to the underlying martini.ResponseWriter with a wrong header
Content-Length field, i.e before it is deleted by serveGzip resulting
in a "Conn.Write wrote more than the declared Content-Length" error.
This change adds a defensive measure of deleting Content-Length
before a potential write.
